### PR TITLE
pagination bar fix

### DIFF
--- a/src/components/cards/LofftHeaderPhoto.tsx
+++ b/src/components/cards/LofftHeaderPhoto.tsx
@@ -24,6 +24,8 @@ const LofftHeaderPhoto = ({
       <FlatList
         data={images}
         horizontal
+        snapToInterval={Dimensions.get('window').width}
+        decelerationRate={'fast'}
         showsHorizontalScrollIndicator={false}
         onViewableItemsChanged={onViewableItemsChanged}
         renderItem={({item, index}) => (


### PR DESCRIPTION
# Feature PR

### Linked Issues

- Closes #161 

## _Todo_

<!-- Please enter here what you have todo, and what you have done -->
- Set pagination bar to correctly show which image it is on
- image now snaps, rather than sluggishly dragging towards next image.

## _Use this section to summarise what you are working on_

## Feature description

<!-- Describe here what you are doing -->
- making the Pagination bar look snappy