### PR TITLE
Fix the missing heart icon from the my flats list

### DIFF
--- a/src/components/cards/ListFlatApplicationCard.tsx
+++ b/src/components/cards/ListFlatApplicationCard.tsx
@@ -18,7 +18,6 @@ import noFlatImage from '@Assets/images/no-flat-image.png';
 import {CoreButton} from '@Components/buttons/CoreButton';
 
 const ListFlatApplicationCard = ({
-  id,
   navigation,
   advert,
   isLessor = false,
@@ -90,12 +89,12 @@ const ListFlatApplicationCard = ({
           </View>
           <View style={styles.advertCardButtonsOverlay}>
             <View style={styles.advertCardbuttonsWrap}>
-              {advert.matchP ? (
+              {!isLessor ? (
                 <View>
                   <Pressable
-                    // style={styles.advertCardSaveButton}
+                    style={styles.advertCardSaveButton}
                     onPress={() => {
-                      dispatch(toggleFavorite(id));
+                      dispatch(toggleFavorite(advert.id));
                     }}>
                     {advert.favorite ? (
                       <LofftIcon


### PR DESCRIPTION
The missing heart was checking for the matchp score, this was changed to check if the user is not the lessor, and updated the toggle to accpet advert.id instead of id